### PR TITLE
Migrating from the Observable Object protocol to the Observable macro

### DIFF
--- a/LearnStateManagement/View/Components/CounterControlsView.swift
+++ b/LearnStateManagement/View/Components/CounterControlsView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CounterControlsView: View {
-    @ObservedObject var counter: CounterViewModel
+    var counter: CounterViewModel
     
     var body: some View {
         VStack(spacing: 15) {

--- a/LearnStateManagement/View/Components/CounterDisplayView.swift
+++ b/LearnStateManagement/View/Components/CounterDisplayView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CounterDisplayView: View {
-    @ObservedObject var counter: CounterViewModel
+    var counter: CounterViewModel
     
     var body: some View {
         VStack {

--- a/LearnStateManagement/View/Components/HistoryView.swift
+++ b/LearnStateManagement/View/Components/HistoryView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct HistoryView: View {
-    @ObservedObject var counter: CounterViewModel
+    var counter: CounterViewModel
     
     var body: some View {
         VStack {

--- a/LearnStateManagement/View/ContentView.swift
+++ b/LearnStateManagement/View/ContentView.swift
@@ -8,11 +8,11 @@
 import SwiftUI
 
 struct ContentView: View {
-    @StateObject private var counter = CounterViewModel()
+    @State private var counter = CounterViewModel()
     
     var body: some View {
         VStack(spacing: 20) {
-            Text("All Views Rebuild")
+            Text("Target View Rebuild")
                 .font(.largeTitle)
                 .fontWeight(.bold)
             

--- a/LearnStateManagement/ViewModel/CounterViewModel.swift
+++ b/LearnStateManagement/ViewModel/CounterViewModel.swift
@@ -6,10 +6,12 @@
 //
 
 import Foundation
+import Observation
 
-class CounterViewModel: ObservableObject {
-    @Published var count: Int = 0
-    @Published var history: [String] = []
+@Observable
+class CounterViewModel {
+    var count: Int = 0
+    var history: [String] = []
     
     func increment() {
         count += 1


### PR DESCRIPTION
Migrated according to this document.
- https://developer.apple.com/documentation/swiftui/migrating-from-the-observable-object-protocol-to-the-observable-macro

|Before|After|
|:-:|:-:|
|<video src="https://github.com/user-attachments/assets/cf3cfb9f-b9f3-4126-bc16-8b3b601c74c5">|<video src="https://github.com/user-attachments/assets/b201a22d-da37-4783-8e71-f99166333169">|

The content of WWDC 2023 was also helpful.
https://developer.apple.com/jp/videos/play/wwdc2023/10149/


![スクリーンショット 2025-05-27 12 04 22](https://github.com/user-attachments/assets/9f135a49-c63c-46ac-b062-cb27585f6222)


![スクリーンショット 2025-05-27 12 04 30](https://github.com/user-attachments/assets/8110e228-8007-4345-911b-44cc9b812623)

![スクリーンショット 2025-05-27 12 04 40](https://github.com/user-attachments/assets/b8cb844f-0eaa-4b57-aca5-7defcc122e90)

